### PR TITLE
Add assigning yourself roles via emotes

### DIFF
--- a/TU20Bot/Configuration/Config.cs
+++ b/TU20Bot/Configuration/Config.cs
@@ -19,6 +19,7 @@ namespace TU20Bot.Configuration {
         public DateTime time;
     }
 
+    // Factories -> Special voice channels that are configurable to set up new channels.
     public class FactoryDescription {
         public ulong id;
         public string name;
@@ -29,12 +30,23 @@ namespace TU20Bot.Configuration {
         public Timer timer;
     }
 
+    public class EmoteRolePair {
+        public string emote;
+        public ulong roleId;
+    }
+
+    // Reactors -> Special messages that can assign you roles when you react to them.
+    public class ReactorDescription {
+        public ulong id;
+        public List<EmoteRolePair> pairs = new List<EmoteRolePair>();
+    }
+
     public class Config {
         public const string defaultPath = "config.xml";
         
         public ulong guildId = 230737273350520834; // TU20
         public ulong welcomeChannelId = 736741911150198835; // #bot-testing
-        
+
         public List<string> welcomeMessages = new List<string> {
             "Hello there!",
             "Whats poppin",
@@ -47,6 +59,7 @@ namespace TU20Bot.Configuration {
         };
 
         public readonly List<LogEntry> logs = new List<LogEntry>();
+        public readonly List<ReactorDescription> reactors = new List<ReactorDescription>();
         public readonly List<FactoryDescription> factories = new List<FactoryDescription>();
 
         public static void save(string path, Config config) {


### PR DESCRIPTION
This PR lets you create special messages, where when people react to them they get assigned special roles. The only way to do this right now is by editing the config file.

They're called `reactors` now. :O 



