### PR TITLE
Add JWT authentication

### DIFF
--- a/TU20Bot/Configuration/AuthorizationModule.cs
+++ b/TU20Bot/Configuration/AuthorizationModule.cs
@@ -1,0 +1,106 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+
+using EmbedIO;
+
+using Jose;
+using Newtonsoft.Json;
+
+namespace TU20Bot.Configuration {
+    // I kinda hate Swan.Formatters, I'm going to use Newtonsoft.
+    public class AuthorizationPayload {
+        [JsonProperty]
+        public string issuerName { get; set; }
+        
+        [JsonProperty]
+        public string fullName { get; set; }
+        
+        [JsonProperty]
+        public List<string> permissions { get; set; }
+
+        public bool isValid => issuerName != null && fullName != null && permissions != null;
+    }
+    
+    public class AuthorizationModule : WebModuleBase {
+        private readonly Server server;
+        private readonly IWebModule module;
+        
+        protected override async Task OnRequestAsync(IHttpContext context) {
+            var authorization = context.Request.Headers["Authorization"];
+
+            void error(string text) {
+                context.Response.StatusCode = 400;
+                var writer = new StreamWriter(context.Response.OutputStream);
+                writer.WriteLine(text);
+                writer.Flush();
+            }
+            
+            if (string.IsNullOrEmpty(authorization)) {
+                error("ERROR: No authorization token provided.");
+                return;
+            }
+
+            const string bearerPrefix = "Bearer ";
+            
+            // I completely do not understand this pattern, and I want someone to tell me why. - Taylor
+            if (!authorization.StartsWith(bearerPrefix)) {
+                error("ERROR: Invalid authorization token provided.");
+                return;
+            }
+
+            var token = authorization.Substring(bearerPrefix.Length);
+
+            Exception moduleError = null;
+
+            try {
+                var secret = Encoding.UTF8.GetBytes(server.config.jwtSecret);
+                var result = JWT.Decode(token, secret);
+
+                if (string.IsNullOrEmpty(result)) {
+                    error("ERROR: Empty payload.");
+                    return;
+                }
+
+                var payload = JsonConvert.DeserializeObject<AuthorizationPayload>(result);
+
+                if (payload == null || !payload.isValid) {
+                    error("ERROR: Invalid payload.");
+                    return;
+                }
+
+                if (!payload.permissions.Contains("admin")) {
+                    error("ERROR: Missing permissions.");
+                    return;
+                }
+
+                Console.WriteLine(
+                    "[Authorization] Access from {0} allowed by {1} to \"{2}\".",
+                    payload.fullName, payload.issuerName, context.Request.Url);
+
+                try {
+                    await module.HandleRequestAsync(context);
+                } catch (Exception e) {
+                    moduleError = e;
+                }
+            } catch (IntegrityException) {
+                error("ERROR: Invalid JWT signature.");
+            } catch (Exception) {
+                error("Error: Failure to parse JWT.");
+            }
+
+            if (moduleError != null) {
+                throw moduleError;
+            }
+        }
+
+        public AuthorizationModule(string baseRoute, Server server, IWebModule module) : base(baseRoute) {
+            this.server = server;
+            this.module = module;
+        }
+
+        public override bool IsFinalHandler => module.IsFinalHandler;
+    }
+}

--- a/TU20Bot/Configuration/Config.cs
+++ b/TU20Bot/Configuration/Config.cs
@@ -59,12 +59,14 @@ namespace TU20Bot.Configuration {
     public class Config {
         private const string tokenVariableName = "tu20_bot_token";
         private const string mongoVariableName = "tu20_mongodb_url";
+        private const string jwtSecretVariableName = "tu20_jwt_secret";
         private const string databaseVariableName = "tu20_database_name";
 
         private const string defaultDatabaseName = "tu20bot";
         
         public string token;
         public string mongoUrl;
+        public string jwtSecret;
         public string databaseName = defaultDatabaseName;
         
         public const string defaultPath = "config.xml";
@@ -101,8 +103,9 @@ namespace TU20Bot.Configuration {
             var environmentToken = Environment.GetEnvironmentVariable(tokenVariableName);
             var environmentMongo = Environment.GetEnvironmentVariable(mongoVariableName);
             var environmentDatabase = Environment.GetEnvironmentVariable(databaseVariableName);
+            var environmentJwtSecret = Environment.GetEnvironmentVariable(jwtSecretVariableName);
 
-            if (string.IsNullOrEmpty(environmentToken))
+            if (string.IsNullOrEmpty(environmentToken) || string.IsNullOrEmpty(environmentJwtSecret))
                 return null;
             
             Console.WriteLine("Configuring from environment variables...");
@@ -110,6 +113,7 @@ namespace TU20Bot.Configuration {
             return new Config {
                 token = environmentToken,
                 mongoUrl = environmentMongo?.NullIfEmpty(),
+                jwtSecret = environmentJwtSecret,
                 databaseName = environmentDatabase?.NullIfEmpty() ?? defaultDatabaseName
             };
         }
@@ -139,6 +143,13 @@ namespace TU20Bot.Configuration {
                 Console.WriteLine("Discord Bot Token is required. Exiting...");
                 Environment.Exit(1);
             }
+            
+            Console.Write(" * JWT Secret Key (required): ");
+            var secret = Console.ReadLine();
+            if (string.IsNullOrEmpty(secret)) {
+                Console.WriteLine("JWT Secret Key is required. Exiting...");
+                Environment.Exit(1);
+            }
 
             Console.Write(" * MongoDB URL (optional): ");
             var databaseUrl = Console.ReadLine()?.NullIfEmpty();
@@ -153,6 +164,7 @@ namespace TU20Bot.Configuration {
             var result = new Config {
                 token = token,
                 mongoUrl = databaseUrl,
+                jwtSecret = secret,
                 databaseName = databaseName ?? defaultDatabaseName
             };
             

--- a/TU20Bot/Configuration/Controllers/AuthenticationController.cs
+++ b/TU20Bot/Configuration/Controllers/AuthenticationController.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Security.Cryptography;
+using System.Text;
+using EmbedIO;
+using EmbedIO.Routing;
+using EmbedIO.WebApi;
+using Jose;
+
+namespace TU20Bot.Configuration.Controllers {
+    public class AuthenticationController: ServerController {
+        public const int HASH_SIZE = 24;
+        private const int ITERATIONS = 1000000;
+        private static readonly string tempSalt = Environment.GetEnvironmentVariable("TEMPSALT");
+        private static readonly string tempSalt_default = "TEMPSALT";
+
+        [Route(HttpVerbs.Post, "/login")]
+        public string Login([QueryField] string password) {
+
+            var stringHash = hashPassword(password);
+            if(stringHash.Equals(this.server.config.consolePassword))
+                return JWT.Encode(new AuthorizationPayload{
+                    fullName = "Admin",
+                    validUntil = DateTime.Now.AddHours(1) // Expire in 1 hour
+                }, Encoding.UTF8.GetBytes(this.server.config.jwtSecret), JwsAlgorithm.HS256);
+
+            return null;
+        }
+
+        /// <summary>
+        /// Given a password string, create a PBKDF2 Hash
+        /// </summary>
+        public static string hashPassword(string password) {
+            Rfc2898DeriveBytes pbkdf2 = new Rfc2898DeriveBytes(password, Encoding.UTF8.GetBytes(tempSalt != null ? tempSalt : tempSalt_default), ITERATIONS);
+            return Convert.ToBase64String(pbkdf2.GetBytes(HASH_SIZE));
+        }
+    }
+}

--- a/TU20Bot/Configuration/Controllers/AuthenticationController.cs
+++ b/TU20Bot/Configuration/Controllers/AuthenticationController.cs
@@ -10,8 +10,7 @@ namespace TU20Bot.Configuration.Controllers {
     public class AuthenticationController: ServerController {
         public const int HASH_SIZE = 24;
         private const int ITERATIONS = 1000000;
-        private static readonly string tempSalt = Environment.GetEnvironmentVariable("TEMPSALT");
-        private static readonly string tempSalt_default = "TEMPSALT";
+        private static readonly string tempSalt = Environment.GetEnvironmentVariable("TEMPSALT") ?? "TEMPSALT";
 
         [Route(HttpVerbs.Post, "/login")]
         public string Login([QueryField] string password) {

--- a/TU20Bot/Configuration/Payloads/FactoryJsonPayload.cs
+++ b/TU20Bot/Configuration/Payloads/FactoryJsonPayload.cs
@@ -3,7 +3,7 @@ using Swan.Formatters;
 namespace TU20Bot.Configuration.Payloads {
     internal class FactoryJsonPayload {
         [JsonProperty("name")]
-        public string name { get; set;  }
+        public string name { get; set; }
         
         [JsonProperty("maxChannels")]
         public int maxChannels { get; set; }

--- a/TU20Bot/Configuration/Server.cs
+++ b/TU20Bot/Configuration/Server.cs
@@ -6,8 +6,6 @@ using TU20Bot.Configuration.Controllers;
 
 namespace TU20Bot.Configuration {
     public class Server : WebServer {
-        private const string hostIp = "http://127.0.0.1";
-        private const string hostLocal = "http://localhost";
         private const string allSources = "http://+";
         private const int port = 3000;
 
@@ -15,7 +13,7 @@ namespace TU20Bot.Configuration {
         public readonly Config config;
 
         private Func<T> createFactory<T>() where T : ServerController, new() {
-            return () => new T() { server = this };
+            return () => new T { server = this };
         }
 
         public Server(Client client) : base(e => e
@@ -23,17 +21,19 @@ namespace TU20Bot.Configuration {
             .WithMode(HttpListenerMode.EmbedIO)) {
             this.client = client;
             config = client.config;
-            
+
+            var api = new WebApiModule("/")
+                .WithController(createFactory<PingController>())
+                .WithController(createFactory<WelcomeController>())
+                .WithController(createFactory<DiscordController>())
+                .WithController(createFactory<LogController>())
+                .WithController(createFactory<CommitController>())
+                .WithController(createFactory<FactoryController>())
+                .WithController(createFactory<MatchController>());
+
             this
                 .WithLocalSessionManager()
-                .WithWebApi("/", e => e
-                    .WithController(createFactory<PingController>())
-                    .WithController(createFactory<WelcomeController>())
-                    .WithController(createFactory<DiscordController>())
-                    .WithController(createFactory<LogController>())
-                    .WithController(createFactory<CommitController>())
-                    .WithController(createFactory<FactoryController>())
-                    .WithController(createFactory<MatchController>()));
+                .WithModule(new AuthorizationModule("/", this, api));
         }
     }
 }

--- a/TU20Bot/Configuration/Server.cs
+++ b/TU20Bot/Configuration/Server.cs
@@ -32,6 +32,7 @@ namespace TU20Bot.Configuration {
                 .WithController(createFactory<MatchController>());
 
             this
+                .WithWebApi("/admin", m => m.WithController(createFactory<AuthenticationController>()))
                 .WithLocalSessionManager()
                 .WithModule(new AuthorizationModule("/", this, api));
         }

--- a/TU20Bot/Program.cs
+++ b/TU20Bot/Program.cs
@@ -38,9 +38,9 @@ namespace TU20Bot {
             client = new Client(config, database);
             
             handler = new Handler(client);
-
+            
             await handler.init();
-
+            
             await client.LoginAsync(TokenType.Bot, config.token);
             await client.StartAsync();
 

--- a/TU20Bot/TU20Bot.csproj
+++ b/TU20Bot/TU20Bot.csproj
@@ -9,6 +9,7 @@
       <PackageReference Include="CsvHelper" Version="15.0.5" />
       <PackageReference Include="Discord.Net" Version="2.2.0" />
       <PackageReference Include="EmbedIO" Version="3.4.3" />
+      <PackageReference Include="jose-jwt" Version="2.6.1" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.6" />
       <PackageReference Include="MongoDB.Driver" Version="2.11.3" />
       <PackageReference Include="NPOI" Version="2.5.1" />


### PR DESCRIPTION
Some changes:
 - Every HTTP request to the bot backend has to include an 'Authorization' header. Set it to `Bearer ` concated with the token.
 - New `tu20_jwt_secret` environment variable added, required on set up.
 - Anyone who knows the value of `tu20_jwt_secret` can sign a new key using jwt cli tools or [this handy website](https://jwt.io).
- This means we don't have to keep track of anyone in a database :O Exciting stuff.

<img width="1086" alt="Screen Shot 2020-12-01 at 3 18 50 PM" src="https://user-images.githubusercontent.com/32211852/100792503-b9595200-33e8-11eb-9e47-9f2544fea31e.png">
