### PR TITLE
Authentication with jwt

### DIFF
--- a/TU20Bot/Configuration/AuthorizationModule.cs
+++ b/TU20Bot/Configuration/AuthorizationModule.cs
@@ -37,7 +37,7 @@ namespace TU20Bot.Configuration {
         }
 
         protected override async Task OnRequestAsync(IHttpContext context) {
-            if (!ValidateToken(context.Request, context.Response)) {
+            if (!validateToken(context.Request, context.Response)) {
                 throw HttpException.Unauthorized();
             }
 
@@ -99,7 +99,7 @@ namespace TU20Bot.Configuration {
         /// <param name="request"></param>
         /// <param name="response"></param>
         /// <returns></returns>
-        public static bool ValidateToken(IHttpRequest request, IHttpResponse response) {
+        public static bool validateToken(IHttpRequest request, IHttpResponse response) {
             var authorization = request.Headers["Authorization"];
 
             if (string.IsNullOrEmpty(authorization)) {
@@ -124,8 +124,8 @@ namespace TU20Bot.Configuration {
         /// <param name="response"></param>
         /// <param name="jwtSecret"></param>
         /// <returns></returns>
-        public static bool ValidatePermissions(List<string> permissions, IHttpRequest request, IHttpResponse response, string jwtSecret) {
-            if (!ValidateToken(request, response)) return false;
+        public static bool validatePermissions(List<string> permissions, IHttpRequest request, IHttpResponse response, string jwtSecret) {
+            if (!validateToken(request, response)) return false;
 
             var authorization = request.Headers["Authorization"];
 

--- a/TU20Bot/Configuration/AuthorizationModule.cs
+++ b/TU20Bot/Configuration/AuthorizationModule.cs
@@ -134,7 +134,7 @@ namespace TU20Bot.Configuration {
         /// <param name="response"></param>
         /// <param name="jwtSecret"></param>
         /// <returns></returns>
-        public static bool validatePermissions(List<string> permissions, string httpHeader, string jwtSecret) {
+        public static bool validatePermissions(IEnumerable<string> permissions, string httpHeader, string jwtSecret) {
             if (tokenExists(httpHeader) != null) return false;
 
             var authorizationHeader = httpHeader;

--- a/TU20Bot/Configuration/AuthorizationModule.cs
+++ b/TU20Bot/Configuration/AuthorizationModule.cs
@@ -8,43 +8,40 @@ using EmbedIO;
 
 using Jose;
 using Newtonsoft.Json;
+using System.Linq;
 
 namespace TU20Bot.Configuration {
     // I kinda hate Swan.Formatters, I'm going to use Newtonsoft.
     public class AuthorizationPayload {
-        
+
         [JsonProperty]
         public string fullName { get; set; }
 
         [JsonProperty]
         public DateTime validUntil { get; set; }
+
+        [JsonProperty]
+        public List<string> permissions { get; set; }
     }
-    
+
     public class AuthorizationModule : WebModuleBase {
         private readonly Server server;
         private readonly IWebModule module;
         private const string bearerPrefix = "Bearer ";
 
+        private static void error(string text, IHttpResponse response) {
+            response.StatusCode = 400;
+            var writer = new StreamWriter(response.OutputStream);
+            writer.WriteLine(text);
+            writer.Flush();
+        }
+
         protected override async Task OnRequestAsync(IHttpContext context) {
+            if (!ValidateToken(context.Request, context.Response)) {
+                throw HttpException.Unauthorized();
+            }
+
             var authorization = context.Request.Headers["Authorization"];
-
-            void error(string text) {
-                context.Response.StatusCode = 400;
-                var writer = new StreamWriter(context.Response.OutputStream);
-                writer.WriteLine(text);
-                writer.Flush();
-            }
-
-            if (string.IsNullOrEmpty(authorization)) {
-                error("ERROR: No authorization token provided.");
-                return;
-            }
-            
-            // I completely do not understand this pattern, and I want someone to tell me why. - Taylor
-            if (!authorization.StartsWith(bearerPrefix)) {
-                error("ERROR: Invalid authorization token provided.");
-                return;
-            }
 
             // Extract the incoming JWT Token from the header
             var token = authorization.Substring(bearerPrefix.Length);
@@ -56,7 +53,7 @@ namespace TU20Bot.Configuration {
                 var result = JWT.Decode(token, secret);
 
                 if (string.IsNullOrEmpty(result)) {
-                    error("ERROR: Empty payload.");
+                    error("ERROR: Empty payload.", context.Response);
                     return;
                 }
 
@@ -64,13 +61,13 @@ namespace TU20Bot.Configuration {
                 var payload = JsonConvert.DeserializeObject<AuthorizationPayload>(result);
 
                 if (payload == null) {
-                    error("ERROR: Invalid payload.");
+                    error("ERROR: Invalid payload.", context.Response);
                     return;
                 }
 
                 // If the token is expired
                 if (DateTime.Now.CompareTo(payload.validUntil) > 0) {
-                    error("ERROR: Expired token.");
+                    error("ERROR: Expired token.", context.Response);
                     return;
                 }
 
@@ -86,13 +83,65 @@ namespace TU20Bot.Configuration {
                 }
 
             } catch (IntegrityException) {
-                error("ERROR: Invalid JWT signature.");
+                error("ERROR: Invalid JWT signature.", context.Response);
             } catch (Exception) {
-                error("Error: Failure to parse JWT.");
+                error("Error: Failure to parse JWT.", context.Response);
             }
 
             if (moduleError != null) {
                 throw moduleError;
+            }
+        }
+
+        /// <summary>
+        /// Check whether the incoming Authorisation header is not null and contains the expected bearer token
+        /// </summary>
+        /// <param name="request"></param>
+        /// <param name="response"></param>
+        /// <returns></returns>
+        public static bool ValidateToken(IHttpRequest request, IHttpResponse response) {
+            var authorization = request.Headers["Authorization"];
+
+            if (string.IsNullOrEmpty(authorization)) {
+                error("ERROR: No authorization token provided.", response);
+                return false;
+            }
+
+            // I completely do not understand this pattern, and I want someone to tell me why. - Taylor
+            if (!authorization.StartsWith(bearerPrefix)) {
+                error("ERROR: Invalid authorization token provided.", response);
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Check if the user of the current session is signed in and if they contain the appropriate permissions
+        /// </summary>
+        /// <param name="permissions"></param>
+        /// <param name="request"></param>
+        /// <param name="response"></param>
+        /// <param name="jwtSecret"></param>
+        /// <returns></returns>
+        public static bool ValidatePermissions(List<string> permissions, IHttpRequest request, IHttpResponse response, string jwtSecret) {
+            if (!ValidateToken(request, response)) return false;
+
+            var authorization = request.Headers["Authorization"];
+
+            // Extract the incoming JWT Token from the header
+            var token = authorization.Substring(bearerPrefix.Length);
+
+            var secret = Encoding.UTF8.GetBytes(jwtSecret);
+
+            try {
+                var result = JWT.Decode(token, secret);
+                var payload = JsonConvert.DeserializeObject<AuthorizationPayload>(result);
+
+                // Return if the payload contains the desired permission information
+                return payload.permissions.Any(_permission => permissions.Contains(_permission));
+            } catch {
+                return false;
             }
         }
 

--- a/TU20Bot/Configuration/AuthorizationModule.cs
+++ b/TU20Bot/Configuration/AuthorizationModule.cs
@@ -1,0 +1,106 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+
+using EmbedIO;
+
+using Jose;
+using Newtonsoft.Json;
+
+namespace TU20Bot.Configuration {
+    // I kinda hate Swan.Formatters, I'm going to use Newtonsoft.
+    public class AuthorizationPayload {
+        [JsonProperty]
+        public string issuerName { get; set; }
+        
+        [JsonProperty]
+        public string fullName { get; set; }
+        
+        [JsonProperty]
+        public List<string> permissions { get; set; }
+
+        public bool isValid => issuerName != null && fullName != null && permissions != null;
+    }
+    
+    public class AuthorizationModule : WebModuleBase {
+        private readonly Server server;
+        private readonly IWebModule module;
+        
+        protected override async Task OnRequestAsync(IHttpContext context) {
+            var authorization = context.Request.Headers["Authorization"];
+
+            void error(string text) {
+                context.Response.StatusCode = 400;
+                var writer = new StreamWriter(context.Response.OutputStream);
+                writer.WriteLine(text);
+                writer.Flush();
+            }
+            
+            if (string.IsNullOrEmpty(authorization)) {
+                error("ERROR: No authorization token provided.");
+                return;
+            }
+
+            const string bearerPrefix = "Bearer ";
+            
+            // I completely do not understand this pattern, and I want someone to tell me why. - Taylor
+            if (!authorization.StartsWith(bearerPrefix)) {
+                error("ERROR: Invalid authorization token provided.");
+                return;
+            }
+
+            var token = authorization.Substring(bearerPrefix.Length);
+
+            Exception moduleError = null;
+
+            try {
+                var secret = Encoding.UTF8.GetBytes(server.config.jwtSecret);
+                var result = JWT.Decode(token, secret);
+
+                if (string.IsNullOrEmpty(result)) {
+                    error("ERROR: Empty payload.");
+                    return;
+                }
+
+                var payload = JsonConvert.DeserializeObject<AuthorizationPayload>(result);
+
+                if (payload == null || !payload.isValid) {
+                    error("ERROR: Invalid payload.");
+                    return;
+                }
+
+                if (!payload.permissions.Contains("admin")) {
+                    error("ERROR: Missing permissions.");
+                    return;
+                }
+
+                Console.WriteLine(
+                    "[Authorization] Access from {0} allowed by {1} to \"{2}\".",
+                    payload.fullName, payload.issuerName, context.Request.Url);
+
+                try {
+                    await module.HandleRequestAsync(context);
+                } catch (Exception e) {
+                    moduleError = e;
+                }
+            } catch (IntegrityException) {
+                error("ERROR: Invalid JWT signature.");
+            } catch (Exception) {
+                error("Error: Failure to parse JWT.");
+            }
+
+            if (moduleError != null) {
+                throw moduleError;
+            }
+        }
+
+        public AuthorizationModule(string baseRoute, Server server, IWebModule module) : base(baseRoute) {
+            this.server = server;
+            this.module = module;
+        }
+
+        public override bool IsFinalHandler => module.IsFinalHandler;
+    }
+}

--- a/TU20Bot/Configuration/Config.cs
+++ b/TU20Bot/Configuration/Config.cs
@@ -59,12 +59,14 @@ namespace TU20Bot.Configuration {
     public class Config {
         private const string tokenVariableName = "tu20_bot_token";
         private const string mongoVariableName = "tu20_mongodb_url";
+        private const string jwtSecretVariableName = "tu20_jwt_secret";
         private const string databaseVariableName = "tu20_database_name";
 
         private const string defaultDatabaseName = "tu20bot";
         
         public string token;
         public string mongoUrl;
+        public string jwtSecret;
         public string databaseName = defaultDatabaseName;
         
         public const string defaultPath = "config.xml";
@@ -101,8 +103,9 @@ namespace TU20Bot.Configuration {
             var environmentToken = Environment.GetEnvironmentVariable(tokenVariableName);
             var environmentMongo = Environment.GetEnvironmentVariable(mongoVariableName);
             var environmentDatabase = Environment.GetEnvironmentVariable(databaseVariableName);
+            var environmentJwtSecret = Environment.GetEnvironmentVariable(jwtSecretVariableName);
 
-            if (string.IsNullOrEmpty(environmentToken))
+            if (string.IsNullOrEmpty(environmentToken) || string.IsNullOrEmpty(environmentJwtSecret))
                 return null;
             
             Console.WriteLine("Configuring from environment variables...");
@@ -110,6 +113,7 @@ namespace TU20Bot.Configuration {
             return new Config {
                 token = environmentToken,
                 mongoUrl = environmentMongo?.NullIfEmpty(),
+                jwtSecret = environmentJwtSecret,
                 databaseName = environmentDatabase?.NullIfEmpty() ?? defaultDatabaseName
             };
         }
@@ -139,6 +143,13 @@ namespace TU20Bot.Configuration {
                 Console.WriteLine("Discord Bot Token is required. Exiting...");
                 Environment.Exit(1);
             }
+            
+            Console.Write(" * JWT Secret Key (required): ");
+            var secret = Console.ReadLine();
+            if (string.IsNullOrEmpty(secret)) {
+                Console.WriteLine("JWT Secret Key is required. Exiting...");
+                Environment.Exit(1);
+            }
 
             Console.Write(" * MongoDB URL (optional): ");
             var databaseUrl = Console.ReadLine()?.NullIfEmpty();
@@ -153,6 +164,7 @@ namespace TU20Bot.Configuration {
             var result = new Config {
                 token = token,
                 mongoUrl = databaseUrl,
+                jwtSecret = secret,
                 databaseName = databaseName ?? defaultDatabaseName
             };
             

--- a/TU20Bot/Configuration/Config.cs
+++ b/TU20Bot/Configuration/Config.cs
@@ -27,11 +27,11 @@ namespace TU20Bot.Configuration {
         public string name;
         public int maxChannels;
         public readonly List<ulong> channels = new List<ulong>();
-        
+
         [XmlIgnore]
         public Timer timer;
     }
-    
+
     public class UserDetails {
         public string firstName;
         public string lastName;
@@ -63,12 +63,12 @@ namespace TU20Bot.Configuration {
         private const string databaseVariableName = "tu20_database_name";
 
         private const string defaultDatabaseName = "tu20bot";
-        
+
         public string token;
         public string mongoUrl;
         public string jwtSecret;
         public string databaseName = defaultDatabaseName;
-        
+
         public const string defaultPath = "config.xml";
         public ulong guildId = 230737273350520834; // TU20
         public ulong welcomeChannelId = 736741911150198835; // #bot-testing
@@ -92,7 +92,7 @@ namespace TU20Bot.Configuration {
         public static Config load(string path = defaultPath) {
             if (!File.Exists(path))
                 return null;
-            
+
             var serializer = new XmlSerializer(typeof(Config));
             var stream = new FileStream(path, FileMode.Open);
             return (Config)serializer.Deserialize(stream);
@@ -104,10 +104,10 @@ namespace TU20Bot.Configuration {
             var environmentMongo = Environment.GetEnvironmentVariable(mongoVariableName);
             var environmentDatabase = Environment.GetEnvironmentVariable(databaseVariableName);
             var environmentJwtSecret = Environment.GetEnvironmentVariable(jwtSecretVariableName);
-            
-            if (string.IsNullOrEmpty(environmentToken) || string.IsNullOrEmpty(environmentJwtSecret))
+
+            if (string.IsNullOrEmpty(environmentToken))
                 return null;
-            
+
             Console.WriteLine("Configuring from environment variables...");
 
             return new Config {
@@ -117,11 +117,11 @@ namespace TU20Bot.Configuration {
                 databaseName = environmentDatabase?.NullIfEmpty() ?? defaultDatabaseName,
             };
         }
-        
+
         public static Config configure(string[] args) {
             if (args.Length >= 2 && args.First() == "init") {
                 Console.WriteLine("Configuring from command line...");
-                
+
                 return new Config {
                     token = args[1],
                     mongoUrl = args.Length > 2 ? args[2].NullIfEmpty() : null,
@@ -137,37 +137,37 @@ namespace TU20Bot.Configuration {
 
             Console.WriteLine("Configuring from console input...");
 
+            // Request the Discord Bot Token
             Console.Write(" * Discord Bot Token (required): ");
             var token = Console.ReadLine();
             if (string.IsNullOrEmpty(token)) {
                 Console.WriteLine("Discord Bot Token is required. Exiting...");
                 Environment.Exit(1);
             }
-            
-            Console.Write(" * JWT Secret Key (required): ");
-            var secret = Console.ReadLine();
-            if (string.IsNullOrEmpty(secret)) {
-                Console.WriteLine("JWT Secret Key is required. Exiting...");
-                Environment.Exit(1);
-            }
 
+            // Request the JWT secret
+            Console.Write(" * JWT Secret Key: ");
+            var secret = Console.ReadLine()?.NullIfEmpty();
+
+            // Request the MongoDB URL
             Console.Write(" * MongoDB URL (optional): ");
             var databaseUrl = Console.ReadLine()?.NullIfEmpty();
 
             string databaseName = null;
-            
+
+            // If the database URL was provided, request the database name
             if (databaseUrl != null) {
                 Console.Write(" * MongoDB Database Name (optional): ");
                 databaseName = Console.ReadLine()?.NullIfEmpty();
             }
-            
+
             var result = new Config {
                 token = token,
                 mongoUrl = databaseUrl,
                 jwtSecret = secret,
                 databaseName = databaseName ?? defaultDatabaseName,
             };
-            
+
             Console.Write(" * Commit this config (y/N)? ");
             var commit = Console.ReadLine()?.ToLower();
 

--- a/TU20Bot/Configuration/Config.cs
+++ b/TU20Bot/Configuration/Config.cs
@@ -151,13 +151,6 @@ namespace TU20Bot.Configuration {
                 Environment.Exit(1);
             }
 
-            Console.Write(" * Console Password (required): ");
-            var password = Console.ReadLine().Trim().Replace("\n", "");
-            if (string.IsNullOrEmpty(secret)) {
-                Console.WriteLine("Password is required. Exiting...");
-                Environment.Exit(1);
-            }
-            
             Console.Write(" * MongoDB URL (optional): ");
             var databaseUrl = Console.ReadLine()?.NullIfEmpty();
 

--- a/TU20Bot/Configuration/Config.cs
+++ b/TU20Bot/Configuration/Config.cs
@@ -6,7 +6,6 @@ using System.Xml.Serialization;
 using System.Collections.Generic;
 
 using EmbedIO.Utilities;
-using TU20Bot.Configuration.Controllers;
 
 namespace TU20Bot.Configuration {
     public enum LogEvent {
@@ -62,7 +61,6 @@ namespace TU20Bot.Configuration {
         private const string mongoVariableName = "tu20_mongodb_url";
         private const string jwtSecretVariableName = "tu20_jwt_secret";
         private const string databaseVariableName = "tu20_database_name";
-        private const string consolePasswordVariableName = "tu20_console_password";
 
         private const string defaultDatabaseName = "tu20bot";
         
@@ -70,7 +68,6 @@ namespace TU20Bot.Configuration {
         public string mongoUrl;
         public string jwtSecret;
         public string databaseName = defaultDatabaseName;
-        public string consolePassword;
         
         public const string defaultPath = "config.xml";
         public ulong guildId = 230737273350520834; // TU20
@@ -107,8 +104,7 @@ namespace TU20Bot.Configuration {
             var environmentMongo = Environment.GetEnvironmentVariable(mongoVariableName);
             var environmentDatabase = Environment.GetEnvironmentVariable(databaseVariableName);
             var environmentJwtSecret = Environment.GetEnvironmentVariable(jwtSecretVariableName);
-            var consolePassword = Environment.GetEnvironmentVariable(consolePasswordVariableName);
-
+            
             if (string.IsNullOrEmpty(environmentToken) || string.IsNullOrEmpty(environmentJwtSecret))
                 return null;
             
@@ -119,7 +115,6 @@ namespace TU20Bot.Configuration {
                 mongoUrl = environmentMongo?.NullIfEmpty(),
                 jwtSecret = environmentJwtSecret,
                 databaseName = environmentDatabase?.NullIfEmpty() ?? defaultDatabaseName,
-                consolePassword = AuthenticationController.hashPassword(consolePassword)
             };
         }
         
@@ -178,7 +173,6 @@ namespace TU20Bot.Configuration {
                 mongoUrl = databaseUrl,
                 jwtSecret = secret,
                 databaseName = databaseName ?? defaultDatabaseName,
-                consolePassword = AuthenticationController.hashPassword(password)
             };
             
             Console.Write(" * Commit this config (y/N)? ");

--- a/TU20Bot/Configuration/Controllers/AuthenticationController.cs
+++ b/TU20Bot/Configuration/Controllers/AuthenticationController.cs
@@ -26,7 +26,7 @@ namespace TU20Bot.Configuration.Controllers {
 
             if (!user.First().checkPassword(password))
                 throw HttpException.Unauthorized();
-            
+
             return JWT.Encode(new AuthorizationPayload {
                 fullName = username,
                 validUntil = DateTime.Now.AddHours(1), // Expire in 1 hour
@@ -37,7 +37,7 @@ namespace TU20Bot.Configuration.Controllers {
         [Route(HttpVerbs.Post, "/create")]
         public async Task<string> Create([QueryField] string username, [QueryField] string password) {
 
-            if (!AuthorizationModule.validatePermissions(new List<string> { "Admin" }, Request, Response, server.config.jwtSecret)) {
+            if (!AuthorizationModule.validatePermissions(new List<string> { "Admin" }, Request.Headers["Authorization"], server.config.jwtSecret, Response)) {
                 throw HttpException.Forbidden();
             }
 
@@ -61,7 +61,7 @@ namespace TU20Bot.Configuration.Controllers {
         [Route(HttpVerbs.Delete, "/delete")]
         public async Task<string> Delete([QueryField] string username, [QueryField] string password) {
 
-            if (!AuthorizationModule.validatePermissions(new List<string> { "Admin" }, Request, Response, server.config.jwtSecret)) {
+            if (!AuthorizationModule.validatePermissions(new List<string> { "Admin" }, Request.Headers["Authorization"], server.config.jwtSecret, Response)) {
                 throw HttpException.Forbidden();
             }
 

--- a/TU20Bot/Configuration/Controllers/AuthenticationController.cs
+++ b/TU20Bot/Configuration/Controllers/AuthenticationController.cs
@@ -1,36 +1,59 @@
 ﻿using System;
-using System.Security.Cryptography;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using EmbedIO;
 using EmbedIO.Routing;
 using EmbedIO.WebApi;
 using Jose;
+using MongoDB.Driver;
+using TU20Bot.Models;
 
 namespace TU20Bot.Configuration.Controllers {
-    public class AuthenticationController: ServerController {
-        public const int HASH_SIZE = 24;
-        private const int ITERATIONS = 1000000;
-        private static readonly string tempSalt = Environment.GetEnvironmentVariable("TEMPSALT") ?? "TEMPSALT";
+    public class AuthenticationController : ServerController {
 
         [Route(HttpVerbs.Post, "/login")]
-        public string Login([QueryField] string password) {
+        public async Task<string> Login([QueryField] string username, [QueryField] string password) {
 
-            var stringHash = hashPassword(password);
-            if(stringHash.Equals(this.server.config.consolePassword))
-                return JWT.Encode(new AuthorizationPayload{
-                    fullName = "Admin",
-                    validUntil = DateTime.Now.AddHours(1) // Expire in 1 hour
+            var user = await server.client.database.GetCollection<AccountModel>(AccountModel.collectionName).FindAsync(_user => _user.username.Equals(username.ToLower()));
+
+            if (!user.Any()) {
+                throw HttpException.Unauthorized();
+            }
+
+            if (user.First().checkPassword(password)) {
+                return JWT.Encode(new AuthorizationPayload {
+                    fullName = username,
+                    validUntil = DateTime.Now.AddHours(1), // Expire in 1 hour
+                    permissions = user.First().permissions
                 }, Encoding.UTF8.GetBytes(this.server.config.jwtSecret), JwsAlgorithm.HS256);
+            }
 
-            return null;
+            throw HttpException.Unauthorized();
         }
 
-        /// <summary>
-        /// Given a password string, create a PBKDF2 Hash
-        /// </summary>
-        public static string hashPassword(string password) {
-            Rfc2898DeriveBytes pbkdf2 = new Rfc2898DeriveBytes(password, Encoding.UTF8.GetBytes(tempSalt != null ? tempSalt : tempSalt_default), ITERATIONS);
-            return Convert.ToBase64String(pbkdf2.GetBytes(HASH_SIZE));
+        [Route(HttpVerbs.Post, "/create")]
+        public async Task<string> Create([QueryField] string username, [QueryField] string password) {
+
+            if (!AuthorizationModule.ValidatePermissions(new List<string> { "Admin" }, Request, Response, server.config.jwtSecret)) {
+                throw HttpException.Forbidden();
+            }
+
+            var user = server.client.database.GetCollection<AccountModel>(AccountModel.collectionName).Find(_user => _user.username.Equals(username.ToLower()));
+
+            // If a user already exists, it is not possible to create a new user
+            if (user.Any()) throw HttpException.NotAcceptable();
+
+            var _user = new AccountModel {
+                username = username.ToLower(),
+                permissions = new List<string> { "Admin" }
+            };
+            _user.setPassword(password);
+
+            await server.client.database.GetCollection<AccountModel>(AccountModel.collectionName).InsertOneAsync(_user);
+
+            return username.ToLower();
         }
     }
 }

--- a/TU20Bot/Configuration/Controllers/AuthenticationController.cs
+++ b/TU20Bot/Configuration/Controllers/AuthenticationController.cs
@@ -67,7 +67,6 @@ namespace TU20Bot.Configuration.Controllers {
             var usersCollection = server.client.database.GetCollection<AccountModel>(AccountModel.collectionName);
             var user = usersCollection.Find(_user => _user.username.Equals(username.ToLower()));
 
-            // If a user already exists, it is not possible to create a new user
             if (!user.Any()) throw HttpException.NotFound();
 
             var _user = user.First();

--- a/TU20Bot/Configuration/Controllers/AuthenticationController.cs
+++ b/TU20Bot/Configuration/Controllers/AuthenticationController.cs
@@ -37,7 +37,7 @@ namespace TU20Bot.Configuration.Controllers {
         [Route(HttpVerbs.Post, "/create")]
         public async Task<string> Create([QueryField] string username, [QueryField] string password) {
 
-            if (!AuthorizationModule.ValidatePermissions(new List<string> { "Admin" }, Request, Response, server.config.jwtSecret)) {
+            if (!AuthorizationModule.validatePermissions(new List<string> { "Admin" }, Request, Response, server.config.jwtSecret)) {
                 throw HttpException.Forbidden();
             }
 
@@ -61,7 +61,7 @@ namespace TU20Bot.Configuration.Controllers {
         [Route(HttpVerbs.Delete, "/delete")]
         public async Task<string> Delete([QueryField] string username, [QueryField] string password) {
 
-            if (!AuthorizationModule.ValidatePermissions(new List<string> { "Admin" }, Request, Response, server.config.jwtSecret)) {
+            if (!AuthorizationModule.validatePermissions(new List<string> { "Admin" }, Request, Response, server.config.jwtSecret)) {
                 throw HttpException.Forbidden();
             }
 

--- a/TU20Bot/Configuration/Controllers/AuthenticationController.cs
+++ b/TU20Bot/Configuration/Controllers/AuthenticationController.cs
@@ -16,7 +16,7 @@ namespace TU20Bot.Configuration.Controllers {
         [Route(HttpVerbs.Post, "/login")]
         public async Task<string> Login([QueryField] string username, [QueryField] string password) {
 
-            var user = await server.client.database.GetCollection<AccountModel>(AccountModel.collectionName).FindAsync(_user => _user.username.Equals(username.ToLower()));
+            var user = server.client.database.GetCollection<AccountModel>(AccountModel.collectionName).Find(_user => _user.username.Equals(username.ToLower()));
 
             if (!user.Any()) {
                 throw HttpException.Unauthorized();

--- a/TU20Bot/Configuration/Controllers/AuthenticationController.cs
+++ b/TU20Bot/Configuration/Controllers/AuthenticationController.cs
@@ -14,7 +14,7 @@ namespace TU20Bot.Configuration.Controllers {
     public class AuthenticationController : ServerController {
 
         [Route(HttpVerbs.Post, "/login")]
-        public async Task<string> Login([QueryField] string username, [QueryField] string password) {
+        public string Login([QueryField] string username, [QueryField] string password) {
 
             var user = server.client.database.GetCollection<AccountModel>(AccountModel.collectionName).Find(_user => _user.username.Equals(username.ToLower()));
 
@@ -27,7 +27,7 @@ namespace TU20Bot.Configuration.Controllers {
                     fullName = username,
                     validUntil = DateTime.Now.AddHours(1), // Expire in 1 hour
                     permissions = user.First().permissions
-                }, Encoding.UTF8.GetBytes(this.server.config.jwtSecret), JwsAlgorithm.HS256);
+                }, Encoding.UTF8.GetBytes(server.config.jwtSecret), JwsAlgorithm.HS256);
             }
 
             throw HttpException.Unauthorized();

--- a/TU20Bot/Configuration/Controllers/AuthenticationController.cs
+++ b/TU20Bot/Configuration/Controllers/AuthenticationController.cs
@@ -37,7 +37,8 @@ namespace TU20Bot.Configuration.Controllers {
         [Route(HttpVerbs.Post, "/create")]
         public async Task<string> Create([QueryField] string username, [QueryField] string password) {
 
-            if (!AuthorizationModule.validatePermissions(new List<string> { "Admin" }, Request.Headers["Authorization"], server.config.jwtSecret, Response)) {
+            if (!AuthorizationModule.validatePermissions(new List<string> { "Admin" },
+                Request.Headers["Authorization"], server.config.jwtSecret, Response)) {
                 throw HttpException.Forbidden();
             }
 
@@ -61,7 +62,8 @@ namespace TU20Bot.Configuration.Controllers {
         [Route(HttpVerbs.Delete, "/delete")]
         public async Task<string> Delete([QueryField] string username, [QueryField] string password) {
 
-            if (!AuthorizationModule.validatePermissions(new List<string> { "Admin" }, Request.Headers["Authorization"], server.config.jwtSecret, Response)) {
+            if (!AuthorizationModule.validatePermissions(new List<string> { "Admin" },
+                Request.Headers["Authorization"], server.config.jwtSecret, Response)) {
                 throw HttpException.Forbidden();
             }
 

--- a/TU20Bot/Configuration/Controllers/AuthenticationController.cs
+++ b/TU20Bot/Configuration/Controllers/AuthenticationController.cs
@@ -16,21 +16,22 @@ namespace TU20Bot.Configuration.Controllers {
         [Route(HttpVerbs.Post, "/login")]
         public string Login([QueryField] string username, [QueryField] string password) {
 
-            var user = server.client.database.GetCollection<AccountModel>(AccountModel.collectionName).Find(_user => _user.username.Equals(username.ToLower()));
+            var user = server.client.database
+                .GetCollection<AccountModel>(AccountModel.collectionName)
+                .Find(x => x.username == username.ToLower());
 
             if (!user.Any()) {
                 throw HttpException.Unauthorized();
             }
 
-            if (user.First().checkPassword(password)) {
-                return JWT.Encode(new AuthorizationPayload {
-                    fullName = username,
-                    validUntil = DateTime.Now.AddHours(1), // Expire in 1 hour
-                    permissions = user.First().permissions
-                }, Encoding.UTF8.GetBytes(server.config.jwtSecret), JwsAlgorithm.HS256);
-            }
-
-            throw HttpException.Unauthorized();
+            if (!user.First().checkPassword(password))
+                throw HttpException.Unauthorized();
+            
+            return JWT.Encode(new AuthorizationPayload {
+                fullName = username,
+                validUntil = DateTime.Now.AddHours(1), // Expire in 1 hour
+                permissions = user.First().permissions
+            }, Encoding.UTF8.GetBytes(server.config.jwtSecret), JwsAlgorithm.HS256);
         }
 
         [Route(HttpVerbs.Post, "/create")]

--- a/TU20Bot/Configuration/Controllers/AuthenticationController.cs
+++ b/TU20Bot/Configuration/Controllers/AuthenticationController.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Security.Cryptography;
+using System.Text;
+using EmbedIO;
+using EmbedIO.Routing;
+using EmbedIO.WebApi;
+using Jose;
+
+namespace TU20Bot.Configuration.Controllers {
+    public class AuthenticationController: ServerController {
+        public const int HASH_SIZE = 24;
+        private const int ITERATIONS = 1000000;
+        private static readonly string tempSalt = Environment.GetEnvironmentVariable("TEMPSALT");
+        private static readonly string tempSalt_default = "TEMPSALT";
+
+        [Route(HttpVerbs.Post, "/login")]
+        public string Login([QueryField] string password) {
+
+            var stringHash = hashPassword(password);
+            if(stringHash.Equals(this.server.config.consolePassword))
+                return JWT.Encode(new AuthorizationPayload{
+                    fullName = "Admin",
+                    validUntil = DateTime.Now.AddHours(1) // Expire in 1 hour
+                }, Encoding.UTF8.GetBytes(this.server.config.jwtSecret), JwsAlgorithm.HS256);
+
+            return null;
+        }
+
+        /// <summary>
+        /// Given a password string, create a PBKDF2 Hash
+        /// </summary>
+        public static string hashPassword(string password) {
+            Rfc2898DeriveBytes pbkdf2 = new Rfc2898DeriveBytes(password, Encoding.UTF8.GetBytes(tempSalt != null ? tempSalt : tempSalt_default), ITERATIONS);
+            return Convert.ToBase64String(pbkdf2.GetBytes(HASH_SIZE));
+        }
+    }
+}

--- a/TU20Bot/Configuration/Controllers/AuthenticationController.cs
+++ b/TU20Bot/Configuration/Controllers/AuthenticationController.cs
@@ -10,8 +10,7 @@ namespace TU20Bot.Configuration.Controllers {
     public class AuthenticationController: ServerController {
         public const int HASH_SIZE = 24;
         private const int ITERATIONS = 1000000;
-        private static readonly string tempSalt = Environment.GetEnvironmentVariable("TEMPSALT");
-        private static readonly string tempSalt_default = "TEMPSALT";
+        private static readonly string tempSalt = Environment.GetEnvironmentVariable("TEMPSALT") ?? "TEMPSALT";
 
         [Route(HttpVerbs.Post, "/login")]
         public string Login([QueryField] string password) {

--- a/TU20Bot/Configuration/Payloads/FactoryJsonPayload.cs
+++ b/TU20Bot/Configuration/Payloads/FactoryJsonPayload.cs
@@ -3,7 +3,7 @@ using Swan.Formatters;
 namespace TU20Bot.Configuration.Payloads {
     internal class FactoryJsonPayload {
         [JsonProperty("name")]
-        public string name { get; set;  }
+        public string name { get; set; }
         
         [JsonProperty("maxChannels")]
         public int maxChannels { get; set; }

--- a/TU20Bot/Configuration/Server.cs
+++ b/TU20Bot/Configuration/Server.cs
@@ -6,8 +6,6 @@ using TU20Bot.Configuration.Controllers;
 
 namespace TU20Bot.Configuration {
     public class Server : WebServer {
-        private const string hostIp = "http://127.0.0.1";
-        private const string hostLocal = "http://localhost";
         private const string allSources = "http://+";
         private const int port = 3000;
 
@@ -15,7 +13,7 @@ namespace TU20Bot.Configuration {
         public readonly Config config;
 
         private Func<T> createFactory<T>() where T : ServerController, new() {
-            return () => new T() { server = this };
+            return () => new T { server = this };
         }
 
         public Server(Client client) : base(e => e
@@ -23,17 +21,19 @@ namespace TU20Bot.Configuration {
             .WithMode(HttpListenerMode.EmbedIO)) {
             this.client = client;
             config = client.config;
-            
+
+            var api = new WebApiModule("/")
+                .WithController(createFactory<PingController>())
+                .WithController(createFactory<WelcomeController>())
+                .WithController(createFactory<DiscordController>())
+                .WithController(createFactory<LogController>())
+                .WithController(createFactory<CommitController>())
+                .WithController(createFactory<FactoryController>())
+                .WithController(createFactory<MatchController>());
+
             this
                 .WithLocalSessionManager()
-                .WithWebApi("/", e => e
-                    .WithController(createFactory<PingController>())
-                    .WithController(createFactory<WelcomeController>())
-                    .WithController(createFactory<DiscordController>())
-                    .WithController(createFactory<LogController>())
-                    .WithController(createFactory<CommitController>())
-                    .WithController(createFactory<FactoryController>())
-                    .WithController(createFactory<MatchController>()));
+                .WithModule(new AuthorizationModule("/", this, api));
         }
     }
 }

--- a/TU20Bot/Configuration/Server.cs
+++ b/TU20Bot/Configuration/Server.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using EmbedIO;
 using EmbedIO.WebApi;
 
@@ -31,10 +32,17 @@ namespace TU20Bot.Configuration {
                 .WithController(createFactory<FactoryController>())
                 .WithController(createFactory<MatchController>());
 
-            this
-                .WithWebApi("/admin", m => m.WithController(createFactory<AuthenticationController>()))
-                .WithLocalSessionManager()
-                .WithModule(new AuthorizationModule("/", this, api));
+            // If the JWT secret is null, open all API routes for anonymous access
+            // WARNING: This should only be used for development
+            if (this.config.jwtSecret == null) {
+                this.WithModule(api)
+                    .WithLocalSessionManager();
+            } else {
+                this.WithWebApi("/admin", m => m.WithController(createFactory<AuthenticationController>()))
+                    .WithLocalSessionManager()
+                    .WithModule(new AuthorizationModule("/", this, api));
+            }
+
         }
     }
 }

--- a/TU20Bot/Configuration/Server.cs
+++ b/TU20Bot/Configuration/Server.cs
@@ -32,6 +32,7 @@ namespace TU20Bot.Configuration {
                 .WithController(createFactory<MatchController>());
 
             this
+                .WithWebApi("/admin", m => m.WithController(createFactory<AuthenticationController>()))
                 .WithLocalSessionManager()
                 .WithModule(new AuthorizationModule("/", this, api));
         }

--- a/TU20Bot/Models/AccountModel.cs
+++ b/TU20Bot/Models/AccountModel.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using System;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using MongoDB.Bson.Serialization.Attributes;
+using MongoDB.Bson;
+
+namespace TU20Bot.Models {
+    public class AccountModel {
+        public const int HASH_SIZE = 24;
+        private const int ITERATIONS = 100000;
+
+        public const string collectionName = "user-account-pivot";
+
+        [BsonId]
+        public ObjectId id { get; set; }
+        public string username { get; set; }
+        public List<string> permissions { get; set; }
+        public byte[] salt { get; set; }
+        public string passwordHash { get; set; }
+
+        public void setPassword(string password) {
+            var salt = generateSalt(HASH_SIZE);
+            var passwordBytes = Encoding.UTF8.GetBytes(password);
+
+            this.passwordHash = generateHash(passwordBytes, salt, ITERATIONS, HASH_SIZE);
+            this.salt = salt;
+        }
+
+        public bool checkPassword(string password) {
+            var salt = this.salt;
+            var passwordBytes = Encoding.UTF8.GetBytes(password);
+            var checkPass = generateHash(passwordBytes, salt, ITERATIONS, HASH_SIZE);
+
+            return this.passwordHash.SequenceEqual(checkPass);
+        }
+
+        private static byte[] generateSalt(int length) {
+            var bytes = new byte[length];
+
+            using (var rng = new RNGCryptoServiceProvider()) {
+                rng.GetBytes(bytes);
+            }
+
+            return bytes;
+        }
+
+        /// <summary>
+        /// Given a password string, create a PBKDF2 Hash
+        /// </summary>
+        private static string generateHash(byte[] password, byte[] salt, int iterations, int length) {
+            using var deriveBytes = new Rfc2898DeriveBytes(password, salt, iterations);
+            return Convert.ToBase64String(deriveBytes.GetBytes(length));
+        }
+    }
+}

--- a/TU20Bot/Models/AccountModel.cs
+++ b/TU20Bot/Models/AccountModel.cs
@@ -22,10 +22,10 @@ namespace TU20Bot.Models {
         public string passwordHash { get; set; }
 
         public void setPassword(string password) {
-            var pkpdf2DeriveBytes = new Rfc2898DeriveBytes(password, SALT_SIZE, ITERATIONS);
+            var pbkdf2DeriveBytes = new Rfc2898DeriveBytes(password, SALT_SIZE, ITERATIONS);
 
-            this.passwordHash = Convert.ToBase64String(pkpdf2DeriveBytes.GetBytes(HASH_SIZE));
-            this.salt = pkpdf2DeriveBytes.Salt;
+            this.passwordHash = Convert.ToBase64String(pbkdf2DeriveBytes.GetBytes(HASH_SIZE));
+            this.salt = pbkdf2DeriveBytes.Salt;
         }
 
         public bool checkPassword(string password) {

--- a/TU20Bot/Program.cs
+++ b/TU20Bot/Program.cs
@@ -38,9 +38,9 @@ namespace TU20Bot {
             client = new Client(config, database);
             
             handler = new Handler(client);
-
+            
             await handler.init();
-
+            
             await client.LoginAsync(TokenType.Bot, config.token);
             await client.StartAsync();
 

--- a/TU20Bot/TU20Bot.csproj
+++ b/TU20Bot/TU20Bot.csproj
@@ -9,6 +9,7 @@
       <PackageReference Include="CsvHelper" Version="15.0.5" />
       <PackageReference Include="Discord.Net" Version="2.2.0" />
       <PackageReference Include="EmbedIO" Version="3.4.3" />
+      <PackageReference Include="jose-jwt" Version="2.6.1" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.6" />
       <PackageReference Include="MongoDB.Driver" Version="2.11.3" />
       <PackageReference Include="NPOI" Version="2.5.1" />


### PR DESCRIPTION
This PR extends #9 and adds username and password authentication for users and uses JSON Web Tokens for creating sessions and ensuring claim information authenticity.

The new routes introduced are:
- POST admin/login - anonymous access
- POST admin/create - Admin-only access
- DELETE admin/delete - Admin-only access

The routes also return explicit HTTP Status codes for operations in the `admin` route.
- `admin/login`: 200 (Ok), 401 (Unauthorized)
- `admin/create`: 200, 403 (Forbidden), 406 (Not Acceptable)
- `admin/delete`: 200, 403 (Forbidden), 404 (Not Found), 500 (Internal Server Error)

Note: Currently there are no roles other than admin, accordingly all users created through `admin/create` are granted admin privileges.