### PR TITLE
Add event-indexing cancel functionality

### DIFF
--- a/TU20Bot/Handler.cs
+++ b/TU20Bot/Handler.cs
@@ -161,7 +161,7 @@ namespace TU20Bot {
                     messageContent = message.Content,
                     
                     promptId = prompt.Id,
-                    state = EventState.Draft
+                    isDraft = true
                 });
                 
                 // We also want to create an index for the collection so we can do text searching later.
@@ -216,7 +216,7 @@ namespace TU20Bot {
                     // If an event prompt was deleted,
                     if (promptModel != null) {
                         // If the event state is a draft (not confirmed), then the reference should be removed
-                        if (promptModel.state == EventState.Draft){
+                        if (promptModel.isDraft){
                             eventCollection.DeleteOne(Builders<EventModel>.Filter.Eq(e => e.id, promptModel.id));
                         }
 
@@ -410,10 +410,10 @@ namespace TU20Bot {
                             Builders<EventModel>.Filter.Eq(x => x.authorId, reaction.UserId)
                         ),
 
-                        // If this is a confirmation, then update the state to Confirmed.
+                        // When this is a confirmation event, update the isDraft state to false (if ❌ then it cannot be a confirmation event).
                         // This intentionally avoids checking if any tags were added on the original message so that
                         // the author can leave the current one unindexed such that it will only appear in searches
-                        Builders<EventModel>.Update.Set(x => x.state, reaction.Emote.Name == "✅" ? EventState.Confirmed : EventState.Draft)
+                        Builders<EventModel>.Update.Set(x => x.isDraft, reaction.Emote.Name == "❌")
                     );
                     
                     if (model != null) {

--- a/TU20Bot/Handler.cs
+++ b/TU20Bot/Handler.cs
@@ -143,7 +143,9 @@ namespace TU20Bot {
                         "\n**Currently Available Tags:**\n")
                         .WithFields(Tag.allTags
                         .Select(x => new EmbedFieldBuilder()
-                            .WithName(x.emoji).WithValue(x.commonName).WithIsInline(true)))
+                            .WithName(x.emoji)
+                            .WithValue(x.commonName)
+                            .WithIsInline(true)))
                     .Build());
 
                 // Generates a link to a discord message. There's a case for DM messages, but its unnecessary.

--- a/TU20Bot/Handler.cs
+++ b/TU20Bot/Handler.cs
@@ -139,9 +139,11 @@ namespace TU20Bot {
                         "please react to your original message with one of the following tags. " +
                         "React with ✅ to this prompt to confirm your choices."+
                         "React with ❌ to this prompt to cancel this action.\n\n" +
-                        "**Currently Available Tags:**\n" +
-                        string.Join("\n\n", Tag.allTags.Select(x => $"{x.emoji}   {x.commonName}")) +
-                        "\nDo you have an idea for more tags? *Let us know!*")
+                        "Do you have an idea for more tags? *Let us know!*"+
+                        "\n**Currently Available Tags:**\n")
+                        .WithFields(Tag.allTags
+                        .Select(x => new EmbedFieldBuilder()
+                            .WithName(x.emoji).WithValue(x.commonName).WithIsInline(true)))
                     .Build());
 
                 // Generates a link to a discord message. There's a case for DM messages, but its unnecessary.

--- a/TU20Bot/Handler.cs
+++ b/TU20Bot/Handler.cs
@@ -139,8 +139,9 @@ namespace TU20Bot {
                         "please react to your original message with one of the following tags. " +
                         "React with ✅ to this prompt to confirm your choices."+
                         "React with ❌ to this prompt to cancel this action.\n\n" +
-                        "**Currently Available Tags (more will be added later):**\n" +
-                        string.Join("\n\n", Tag.allTags.Select(x => $"{x.emoji}   {x.commonName}")))
+                        "**Currently Available Tags:**\n" +
+                        string.Join("\n\n", Tag.allTags.Select(x => $"{x.emoji}   {x.commonName}")) +
+                        "\nDo you have an idea for more tags? *Let us know!*")
                     .Build());
 
                 // Generates a link to a discord message. There's a case for DM messages, but its unnecessary.

--- a/TU20Bot/Handler.cs
+++ b/TU20Bot/Handler.cs
@@ -137,9 +137,10 @@ namespace TU20Bot {
                         $"Hey <@{message.Author.Id}>.\n\n" +
                         "To finish submitting your event, " +
                         "please react to your original message with one of the following tags. " +
-                        "React with ✅ to this prompt to confirm your choices."+
+                        "React with ✅ to this prompt to confirm your choices." +
                         "React with ❌ to this prompt to cancel this action.\n\n" +
-                        "Do you have an idea for more tags? *Let us know!*"+
+                        "Do you have an idea for more tags? *Let us know!* " + 
+                        "You can send us a message in the #discussions channel." +
                         "\n**Currently Available Tags:**\n")
                         .WithFields(Tag.allTags
                         .Select(x => new EmbedFieldBuilder()

--- a/TU20Bot/Models/EventModel.cs
+++ b/TU20Bot/Models/EventModel.cs
@@ -39,6 +39,11 @@ namespace TU20Bot.Models {
         };
     }
     
+    public enum EventState {
+        Draft,
+        Confirmed,
+    }
+
     public class EventModel {
         [BsonId]
         public ObjectId id;
@@ -57,5 +62,7 @@ namespace TU20Bot.Models {
 
         // Used by MongoDB to sort.
         public double? textScore;
+
+        public EventState state;
     }
 }

--- a/TU20Bot/Models/EventModel.cs
+++ b/TU20Bot/Models/EventModel.cs
@@ -38,11 +38,6 @@ namespace TU20Bot.Models {
             }
         };
     }
-    
-    public enum EventState {
-        Draft,
-        Confirmed,
-    }
 
     public class EventModel {
         [BsonId]

--- a/TU20Bot/Models/EventModel.cs
+++ b/TU20Bot/Models/EventModel.cs
@@ -63,6 +63,6 @@ namespace TU20Bot.Models {
         // Used by MongoDB to sort.
         public double? textScore;
 
-        public EventState state;
+        public bool isDraft;
     }
 }


### PR DESCRIPTION
This PR introduces the functionality to cancel pending event-index requests. It also adds the concept of "draft" and "confirmed" event-message states to enforce expected behaviour for the following cases:
- The original message is deleted: Same as before.
- The original message is confirmed: Same as before.
- The event prompt is canceled: Remove the event index, the event prompt, and any reactions made by the bot on the users message.
- The event prompt is deleted before confirmation: Same behaviour as above.